### PR TITLE
Demo video updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is part of [mcp-kit](https://github.com/shaharia-lab/mcp-kit) an
 
 Experience MCP Kit in action - chat with LLMs while leveraging additional capabilities provided by the MCP server:
 
-<video src="https://github.com/user-attachments/assets/81804a29-e896-4f65-a929-05ac6a6aa92a" controls title="MCP Kit in action"></video>
+<video src="https://github.com/user-attachments/assets/ff760b5f-7f0c-4b94-a3ca-1b55283bddd4" controls title="MCP Kit in action"></video>
 
 ## 🛠️ Prerequisites
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change updates the video source URL to a new link.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21): Updated the video source URL to `https://github.com/user-attachments/assets/ff760b5f-7f0c-4b94-a3ca-1b55283bddd4`.Demo video updated